### PR TITLE
fix thing for cchn_register to work + add Rproj for mortals :wink:

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -20,8 +20,8 @@ check_token <- function(x = NULL) {
 
 ccc_GET <- function(path, args, token = NULL, ...) {
   headers <- list()
-  token <- check_token(token)
   if (!is.null(token)) {
+    token <- check_token(token)
     headers <- list(Authorization = paste("Bearer", token))
   }
   cli <- crul::HttpClient$new(

--- a/cchecks.Rproj
+++ b/cchecks.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
I'm very excited about the notifications stuff, thanks for working on this! :tada:

## Description

I got an error when running `cchn_register()` because it tried checking the token.

## Further comments

* Why would I need to save the token if it's in the email file? Won't the package functions read the token from there? I was expecting something like `rhub::validate_email()` (with the function returning nothing, just messaging that it saved the token).

* I first run the function without email argument because that's how the README presents it and also because I was expecting an interface similar to `rhub::validate_email()`. I'd actually recommend copying some of `rhub`'s stuff: in an interactive session it tries guessing, and lets the user enter a choice, see [the corresponding R file](https://github.com/r-hub/rhub/blob/6ae6f35e958f3beab1e2c8e6f704affa23c8ce29/R/email.R#L50).

* Will the functions listing rules try to guess what package and email are to be used, like what `rhub` does? 